### PR TITLE
added psycopg requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ibis-framework
 redis
 duckdb
 pyarrow_hotfix
+psycopg


### PR DESCRIPTION
Since this tutorial uses postgres, the backend SQL query engine (sqlalchemy) depends on the `psycopg` library. Without it, you get an error to pip install this when running the tutorial.

I added `psycopg` to the `requirements.txt` file so that users don't face this error.